### PR TITLE
[feat] Command Builder improvements concerning execution syntax

### DIFF
--- a/api-examples/src/main/java/net/zffu/hardened/examples/api/BuilderCommandExample.java
+++ b/api-examples/src/main/java/net/zffu/hardened/examples/api/BuilderCommandExample.java
@@ -4,6 +4,7 @@ import net.zffu.hardened.api.args.Argument;
 import net.zffu.hardened.api.args.ArgumentTypes;
 import net.zffu.hardened.api.commands.builder.CommandBuilder;
 import net.zffu.hardened.api.context.CommandContext;
+import net.zffu.hardened.api.invoker.CommandInvoker;
 import net.zffu.hardened.api.invoker.InvokerType;
 
 /**
@@ -14,16 +15,9 @@ public class BuilderCommandExample {
     public static void main(String[] args) {
 
         // Creates the base of the command builder
-        CommandBuilder builder = new CommandBuilder() {
-
-            // Everything in that function will be ran after validation.
-            @Override
-            public void execute(CommandContext commandContext) {
-                String name = commandContext.get(0, String.class); // Gets the first argument of the command.
-                System.out.println("Hello " + name);
-            }
-
-        }
+        CommandBuilder commandBuilder = new CommandBuilder("test").runAction((ctx) -> {
+            System.out.println("Hello " + ctx.getInvoker().getType().name());
+        })
         // Adds properties to the CommandBuilder.
         .allowed(InvokerType.PLAYER) // Makes sure only players can run this command
         .args(new Argument(ArgumentTypes.STRING.get())); // Adds a string argument

--- a/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
@@ -11,7 +11,7 @@ import net.zffu.hardened.api.invoker.InvokerType;
  * @since 0.0.1
  * @see {@link Command}
  */
-public abstract class CommandBuilder extends BuilderCommand {
+public class CommandBuilder extends BuilderCommand {
 
     /**
      * Constructs a new {@link CommandBuilder}.

--- a/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
@@ -5,6 +5,8 @@ import net.zffu.hardened.api.commands.Command;
 import net.zffu.hardened.api.context.CommandContext;
 import net.zffu.hardened.api.invoker.InvokerType;
 
+import java.util.function.Function;
+
 /**
  * <p>Variant of the {@link net.zffu.hardened.api.commands.Command} interface.</p>
  * <p>This variant isn't the default one as it implements every single feature that commands can have in the Hardened for the builder.</p>
@@ -14,6 +16,7 @@ import net.zffu.hardened.api.invoker.InvokerType;
  */
 public class CommandBuilder extends BuilderCommand {
 
+    private Function<CommandContext, ?> executeFunction;
 
     /**
      * Constructs a new {@link CommandBuilder}.
@@ -45,6 +48,6 @@ public class CommandBuilder extends BuilderCommand {
 
     @Override
     public void execute(CommandContext commandContext) {
-
+        if(executeFunction != null) executeFunction.apply(commandContext);
     }
 }

--- a/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
@@ -46,6 +46,16 @@ public class CommandBuilder extends BuilderCommand {
         return this;
     }
 
+    /**
+     * Sets the executeFunction of the command.
+     * @param func
+     * @return
+     */
+    public CommandBuilder runAction(Function<CommandContext, ?> func) {
+        this.executeFunction = func;
+        return this;
+    }
+
     @Override
     public void execute(CommandContext commandContext) {
         if(executeFunction != null) executeFunction.apply(commandContext);

--- a/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
@@ -5,7 +5,9 @@ import net.zffu.hardened.api.commands.Command;
 import net.zffu.hardened.api.context.CommandContext;
 import net.zffu.hardened.api.invoker.InvokerType;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * <p>Variant of the {@link net.zffu.hardened.api.commands.Command} interface.</p>
@@ -16,7 +18,7 @@ import java.util.function.Function;
  */
 public class CommandBuilder extends BuilderCommand {
 
-    private Function<CommandContext, ?> executeFunction;
+    private Consumer<CommandContext> executeFunction;
 
     /**
      * Constructs a new {@link CommandBuilder}.
@@ -51,13 +53,13 @@ public class CommandBuilder extends BuilderCommand {
      * @param func
      * @return
      */
-    public CommandBuilder runAction(Function<CommandContext, ?> func) {
+    public CommandBuilder runAction(Consumer<CommandContext> func) {
         this.executeFunction = func;
         return this;
     }
 
     @Override
     public void execute(CommandContext commandContext) {
-        if(executeFunction != null) executeFunction.apply(commandContext);
+        if(executeFunction != null) executeFunction.accept(commandContext);
     }
 }

--- a/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
@@ -2,6 +2,7 @@ package net.zffu.hardened.api.commands.builder;
 
 import net.zffu.hardened.api.args.Argument;
 import net.zffu.hardened.api.commands.Command;
+import net.zffu.hardened.api.context.CommandContext;
 import net.zffu.hardened.api.invoker.InvokerType;
 
 /**
@@ -12,6 +13,7 @@ import net.zffu.hardened.api.invoker.InvokerType;
  * @see {@link Command}
  */
 public class CommandBuilder extends BuilderCommand {
+
 
     /**
      * Constructs a new {@link CommandBuilder}.
@@ -41,4 +43,8 @@ public class CommandBuilder extends BuilderCommand {
         return this;
     }
 
+    @Override
+    public void execute(CommandContext commandContext) {
+
+    }
 }


### PR DESCRIPTION
**Changelog:**
- Made CommandBuilder use a `Consumer` for the `execute` function.
- Added the runAction builder function to allow for inline code execution definition
- Updated the command builder example to follow the new syntax