### PR TITLE
[fix] Swapped .getAllowedInvokerTypes() to be a list to avoid Arrays.asList operations

### DIFF
--- a/api-examples/src/main/java/net/zffu/hardened/examples/api/CustomCommandExample.java
+++ b/api-examples/src/main/java/net/zffu/hardened/examples/api/CustomCommandExample.java
@@ -16,12 +16,16 @@ import java.util.List;
 // In this example we create a invoker gated command.
 public class CustomCommandExample implements Command, TypeGatedCommand {
 
-    private String[] names = new String[]{"test"};
     private List<InvokerType> allowedInvokers = Arrays.asList(new InvokerType[]{InvokerType.PLAYER}); // Only allows players to use our command, this will not matter at all if the custom validator doesn't include a check for it
 
     @Override
-    public String[] getNames() {
-        return this.names;
+    public String getPrimaryName() {
+        return "test";
+    }
+
+    @Override
+    public String[] getAliases() {
+        return new String[0];
     }
 
     @Override

--- a/api-examples/src/main/java/net/zffu/hardened/examples/api/CustomCommandExample.java
+++ b/api-examples/src/main/java/net/zffu/hardened/examples/api/CustomCommandExample.java
@@ -6,6 +6,9 @@ import net.zffu.hardened.api.commands.validator.CommandValidator;
 import net.zffu.hardened.api.context.CommandContext;
 import net.zffu.hardened.api.invoker.InvokerType;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * An example on how to create your own {@link net.zffu.hardened.api.commands.Command} implementation with the custom features you want.
  */
@@ -14,7 +17,7 @@ import net.zffu.hardened.api.invoker.InvokerType;
 public class CustomCommandExample implements Command, TypeGatedCommand {
 
     private String[] names = new String[]{"test"};
-    private InvokerType[] allowedInvokers = new InvokerType[] {InvokerType.PLAYER}; // Only allows players to use our command, this will not matter at all if the custom validator doesn't include a check for it
+    private List<InvokerType> allowedInvokers = Arrays.asList(new InvokerType[]{InvokerType.PLAYER}); // Only allows players to use our command, this will not matter at all if the custom validator doesn't include a check for it
 
     @Override
     public String[] getNames() {
@@ -32,7 +35,7 @@ public class CustomCommandExample implements Command, TypeGatedCommand {
     }
 
     @Override
-    public InvokerType[] getAllowedInvokers() {
+    public List<InvokerType> getAllowedInvokers() {
         return this.allowedInvokers;
     }
 }

--- a/api-examples/src/main/java/net/zffu/hardened/examples/api/CustomCommandValidator.java
+++ b/api-examples/src/main/java/net/zffu/hardened/examples/api/CustomCommandValidator.java
@@ -15,7 +15,7 @@ public class CustomCommandValidator implements CommandValidator<CustomCommandExa
 
     @Override
     public boolean validate(CustomCommandExample command, CommandContext invoker) {
-        if(Arrays.asList(command.getAllowedInvokers()).contains(invoker.getInvoker().getType())) return true; // Could simplify that but its for the sake of the example
+        if(command.getAllowedInvokers().contains(invoker.getInvoker().getType())) return true; // Could simplify that but its for the sake of the example
         return false;
     }
 

--- a/api/src/main/java/net/zffu/hardened/api/commands/builder/BuilderCommand.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/builder/BuilderCommand.java
@@ -8,6 +8,9 @@ import net.zffu.hardened.api.commands.types.PermissionCommand;
 import net.zffu.hardened.api.commands.types.TypeGatedCommand;
 import net.zffu.hardened.api.invoker.InvokerType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * <p>Variant of the {@link net.zffu.hardened.api.commands.Command} interface.</p>
  * <p>This variant isn't the default one as it implements every single feature that commands can have in the Hardened for the builder.</p>
@@ -21,7 +24,7 @@ public abstract class BuilderCommand implements Command<BuilderCommandValidator>
 
     protected String primaryName;
 
-    protected InvokerType[] allowedTypes;
+    protected List<InvokerType> allowedTypes;
 
     protected String[] aliases;
 
@@ -47,7 +50,7 @@ public abstract class BuilderCommand implements Command<BuilderCommandValidator>
     }
 
     @Override
-    public InvokerType[] getAllowedInvokers() {
+    public List<InvokerType> getAllowedInvokers() {
         return this.allowedTypes;
     }
 

--- a/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/builder/CommandBuilder.java
@@ -5,6 +5,8 @@ import net.zffu.hardened.api.commands.Command;
 import net.zffu.hardened.api.context.CommandContext;
 import net.zffu.hardened.api.invoker.InvokerType;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -44,7 +46,7 @@ public class CommandBuilder extends BuilderCommand {
      * @return
      */
     public CommandBuilder allowed(InvokerType... types) {
-        this.allowedTypes = types;
+        this.allowedTypes = Arrays.asList(types);
         return this;
     }
 

--- a/api/src/main/java/net/zffu/hardened/api/commands/types/TypeGatedCommand.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/types/TypeGatedCommand.java
@@ -2,6 +2,8 @@ package net.zffu.hardened.api.commands.types;
 
 import net.zffu.hardened.api.invoker.InvokerType;
 
+import java.util.Collection;
+
 /**
  * A {@link net.zffu.hardened.api.commands.Command} that can onlu run with specific {@link net.zffu.hardened.api.invoker.InvokerType}.
  * @since 1.0.0
@@ -12,6 +14,6 @@ public interface TypeGatedCommand {
      * Gets the list of the {@link InvokerType} that are allowed to run the command.
      * @return {@link InvokerType}.
      */
-    InvokerType[] getAllowedInvokers();
+    Collection<InvokerType> getAllowedInvokers();
 
 }

--- a/api/src/main/java/net/zffu/hardened/api/commands/types/TypeGatedCommand.java
+++ b/api/src/main/java/net/zffu/hardened/api/commands/types/TypeGatedCommand.java
@@ -2,7 +2,7 @@ package net.zffu.hardened.api.commands.types;
 
 import net.zffu.hardened.api.invoker.InvokerType;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
  * A {@link net.zffu.hardened.api.commands.Command} that can onlu run with specific {@link net.zffu.hardened.api.invoker.InvokerType}.
@@ -14,6 +14,6 @@ public interface TypeGatedCommand {
      * Gets the list of the {@link InvokerType} that are allowed to run the command.
      * @return {@link InvokerType}.
      */
-    Collection<InvokerType> getAllowedInvokers();
+    List<InvokerType> getAllowedInvokers();
 
 }


### PR DESCRIPTION
**Changelog:**
- Turned .getAllowedInvokerTypes() into List<InvokerType> instead of InvokerType[]
- Removed repetitive Arrays.asList operations
- Fixed some example code being wrong

close
